### PR TITLE
Scape URL before passing it to add new item view

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/ViewModels/ScanQRCodeViewModel.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/ViewModels/ScanQRCodeViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using BlackLion.QRStore.Views;
 using System.Collections.Generic;
+using System.Web;
 using Xamarin.Forms;
 using ZXing;
 using ZXing.Mobile;
@@ -38,10 +39,11 @@ namespace BlackLion.QRStore.ViewModels
         private void OnScanResult(object obj)
         {
             IsScanning = false;
+            var scappedURL = HttpUtility.UrlEncode((obj as Result).Text);
 
             Device.BeginInvokeOnMainThread(async () =>
             {
-                await Shell.Current.GoToAsync($"{nameof(NewItemPage)}?url={(obj as Result).Text}");
+                await Shell.Current.GoToAsync($"{nameof(NewItemPage)}?url={scappedURL}");
             });
         }
     }

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/NewItemPage.xaml.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/NewItemPage.xaml.cs
@@ -1,14 +1,9 @@
-﻿using BlackLion.QRStore.Models;
-using BlackLion.QRStore.ViewModels;
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 
 namespace BlackLion.QRStore.Views
 {
     public partial class NewItemPage : ContentPage
     {
-        //public string Domain { get; set; }
-        public Item Item { get; set; }
-
         public NewItemPage()
         {
             InitializeComponent();

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/ScanQRCodePage.xaml.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/ScanQRCodePage.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Xamarin.Forms;
+﻿using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace BlackLion.QRStore.Views


### PR DESCRIPTION
The app was previously crashing when a QR code contained an equal sign (**=**), probably the same thing was happening for other characters with special meanings in URLs, this should take care of the issue.