### PR TITLE
Narrow filter in EditItemViewModel.OnSave method 

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/ViewModels/EditItemViewModel.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/ViewModels/EditItemViewModel.cs
@@ -63,7 +63,7 @@ namespace BlackLion.QRStore.ViewModels
         {
             item.Name = name;
             item.URL = url;
-            var duplicatedItem = (await _dataStore.GetItemsAsync()).Find(item => item.URL == url);
+            var duplicatedItem = (await _dataStore.GetItemsAsync()).Find(item => item.URL == url && item.Id != itemId);
 
             if (duplicatedItem != null)
             {


### PR DESCRIPTION
User was not able to update a record's name while keeping the same URL because we we're checking if that URL already existed in the database but not considering the id. By adding this extra check we can ignore the record with the same id as the one we are editing.