### PR TITLE
Move initializing options to code-behind.

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/ViewModels/ScanQRCodeViewModel.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/ViewModels/ScanQRCodeViewModel.cs
@@ -1,26 +1,18 @@
 ﻿using BlackLion.QRStore.Views;
-using System.Collections.Generic;
 using System.Web;
 using Xamarin.Forms;
 using ZXing;
-using ZXing.Mobile;
 
 namespace BlackLion.QRStore.ViewModels
 {
     public class ScanQRCodeViewModel : BaseViewModel
     {
         private bool isScanning;
-        private MobileBarcodeScanningOptions options;
 
         public bool IsScanning
         {
             get => isScanning;
             set => SetProperty(ref isScanning, value);
-        }
-        public MobileBarcodeScanningOptions Options
-        {
-            get => options;
-            set => SetProperty(ref options, value);
         }
 
         public Command ScanResultCommand { get; }
@@ -28,10 +20,6 @@ namespace BlackLion.QRStore.ViewModels
         public ScanQRCodeViewModel()
         {
             Title = "Scan";
-            var Options = new MobileBarcodeScanningOptions();
-            Options.PossibleFormats = new List<BarcodeFormat>() {
-                BarcodeFormat.QR_CODE
-            };
             IsScanning = true;
             ScanResultCommand = new Command(OnScanResult);
         }

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/ScanQRCodePage.xaml
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/ScanQRCodePage.xaml
@@ -12,7 +12,6 @@
         <StackLayout>
             <Grid HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand">
                 <zxing:ZXingScannerView IsScanning="{Binding IsScanning}"
-                                        Options="{Binding Options}"
                                         ScanResultCommand="{Binding ScanResultCommand}"
                                         x:Name="QRScanner"/>
                 <zxing:ZXingDefaultOverlay/>

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/ScanQRCodePage.xaml.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/ScanQRCodePage.xaml.cs
@@ -1,14 +1,21 @@
-﻿using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
+﻿using System.Collections.Generic;
+using Xamarin.Forms;
+using ZXing;
+using ZXing.Mobile;
 
 namespace BlackLion.QRStore.Views
 {
-    [XamlCompilation(XamlCompilationOptions.Compile)]
     public partial class ScanQRCodePage : ContentPage
     {
         public ScanQRCodePage()
         {
             InitializeComponent();
+
+            var options = new MobileBarcodeScanningOptions();
+            options.PossibleFormats = new List<BarcodeFormat>() {
+                BarcodeFormat.QR_CODE
+            };
+            QRScanner.Options = options;
         }
 
         private void OnFlashButtonClicked(object sender, System.EventArgs e)


### PR DESCRIPTION
Binding to Options was being ignored in XAML, the implementation was moved to code-behind and it just works. A similar thing happened with the ZXingDefaultOverlay view and the flash command.