### PR TITLE
URL's that don't specify protocol can now be open

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/Helpers/URLValidatorHelper.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Helpers/URLValidatorHelper.cs
@@ -2,14 +2,24 @@
 
 namespace BlackLion.QRStore.Helpers
 {
-    internal class URLValidatorHelper
+    public class URLHelper
     {
-        public static bool IsValidURL(string URL)
+        public static bool IsValid(string URL)
         {
             string Pattern = @"^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$";
             Regex Rgx = new Regex(Pattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             
             return Rgx.IsMatch(URL);
+        }
+
+        public static string NormalizeURL(string URL)
+        {
+            if (!URL.StartsWith("http://") || !URL.StartsWith("https://"))
+            {
+                return "http://" + URL;
+            }
+
+            return URL;
         }
     }
 }

--- a/BlackLion.QRStore/BlackLion.QRStore/ViewModels/EditItemViewModel.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/ViewModels/EditItemViewModel.cs
@@ -94,7 +94,7 @@ namespace BlackLion.QRStore.ViewModels
                 return false;
             }
 
-            IsValidURL = URLValidatorHelper.IsValidURL(url);
+            IsValidURL = URLHelper.IsValid(url);
 
             return !String.IsNullOrWhiteSpace(url) &&
                 !String.IsNullOrWhiteSpace(name) &&

--- a/BlackLion.QRStore/BlackLion.QRStore/ViewModels/ItemDetailViewModel.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/ViewModels/ItemDetailViewModel.cs
@@ -1,4 +1,5 @@
-﻿using BlackLion.QRStore.Localization;
+﻿using BlackLion.QRStore.Helpers;
+using BlackLion.QRStore.Localization;
 using BlackLion.QRStore.Models;
 using BlackLion.QRStore.Services;
 using BlackLion.QRStore.Views;
@@ -94,6 +95,8 @@ namespace BlackLion.QRStore.ViewModels
         {
             try
             {
+                item.URL = URLHelper.NormalizeURL(item.URL);
+
                 await Browser.OpenAsync(item.URL, BrowserLaunchMode.SystemPreferred);
             }
             catch (Exception)

--- a/BlackLion.QRStore/BlackLion.QRStore/ViewModels/NewItemViewModel.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/ViewModels/NewItemViewModel.cs
@@ -58,7 +58,7 @@ namespace BlackLion.QRStore.ViewModels
                 return false;
             }
 
-            IsValidURL = URLValidatorHelper.IsValidURL(URL);
+            IsValidURL = URLHelper.IsValid(URL);
 
             return !string.IsNullOrWhiteSpace(url) &&
                 !string.IsNullOrWhiteSpace(name) &&
@@ -67,7 +67,7 @@ namespace BlackLion.QRStore.ViewModels
 
         public void ApplyQueryAttributes(IDictionary<string, string> query)
         {
-            URL = HttpUtility.UrlDecode(query["url"]);
+            URL = URLHelper.NormalizeURL(HttpUtility.UrlDecode(query["url"]));
         }
 
         private async Task OnCancel()


### PR DESCRIPTION
Previously trying to open a domain that didn't specify HTTP or HTTPS protocol would end up in an error message (think google.com instead of http(s)://google.com), now we are checking for that before trying to open them.