### PR TITLE
Fix protocol checking logic

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/Helpers/URLValidatorHelper.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Helpers/URLValidatorHelper.cs
@@ -14,7 +14,7 @@ namespace BlackLion.QRStore.Helpers
 
         public static string NormalizeURL(string URL)
         {
-            if (!URL.StartsWith("http://") || !URL.StartsWith("https://"))
+            if (!URL.StartsWith("http://") && !URL.StartsWith("https://"))
             {
                 return "http://" + URL;
             }


### PR DESCRIPTION
Logic in URLValidatorHelper.NormalizeURL was flawed, changing the operators did the trick.