### PR TITLE
Add focus to name entry in add and edit view

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/Views/EditItemPage.xaml
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/EditItemPage.xaml
@@ -12,7 +12,8 @@
         <StackLayout Spacing="3" Padding="15">
             <Entry FontSize="Medium"
                    Placeholder="{x:Static resources:EditItemPageResources.Entry_Placeholder_Name}"
-                   Text="{Binding Name}"/>
+                   Text="{Binding Name}"
+                   x:Name="nameEntry"/>
             <Entry FontSize="Medium"
                    IsSpellCheckEnabled="False" 
                    IsTextPredictionEnabled="False"

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/EditItemPage.xaml.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/EditItemPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System.Threading.Tasks;
+using Xamarin.Forms;
 
 namespace BlackLion.QRStore.Views
 {
@@ -7,6 +8,18 @@ namespace BlackLion.QRStore.Views
         public EditItemPage()
         {
             InitializeComponent();
+        }
+
+        protected async override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            while (!nameEntry.Focus())
+            {
+                await Task.Delay(50);
+            }
+
+            nameEntry.CursorPosition = nameEntry.Text.Length;
         }
     }
 }

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/NewItemPage.xaml
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/NewItemPage.xaml
@@ -15,7 +15,8 @@
         <StackLayout Padding="15" Spacing="10">
             <Entry FontSize="Medium"
                    Placeholder="{x:Static resources:NewItemPageResources.Entry_Name_Placeholder}"
-                   Text="{Binding Name}"/>
+                   Text="{Binding Name}"
+                   x:Name="nameEntry"/>
             <Entry FontSize="Medium"
                    IsSpellCheckEnabled="False" 
                    IsTextPredictionEnabled="False"

--- a/BlackLion.QRStore/BlackLion.QRStore/Views/NewItemPage.xaml.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/Views/NewItemPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms;
+﻿using System.Threading.Tasks;
+using Xamarin.Forms;
 
 namespace BlackLion.QRStore.Views
 {
@@ -7,6 +8,16 @@ namespace BlackLion.QRStore.Views
         public NewItemPage()
         {
             InitializeComponent();
+        }
+
+        protected async override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            while (!nameEntry.Focus())
+            {
+                await Task.Delay(50);
+            }
         }
     }
 }


### PR DESCRIPTION
Name entry is now focus by default when user tries to add a new link or edit an existing one