### PR TITLE
Add back button behavior for shell content

### DIFF
--- a/BlackLion.QRStore/BlackLion.QRStore/AppShell.xaml.cs
+++ b/BlackLion.QRStore/BlackLion.QRStore/AppShell.xaml.cs
@@ -1,13 +1,18 @@
 ﻿using BlackLion.QRStore.Views;
 using System;
+using System.Collections.Generic;
 using Xamarin.Forms;
 
 namespace BlackLion.QRStore
 {
     public partial class AppShell : Shell
     {
+        private List<string> _history;
+        private string _action = "DEFAULT";
+
         public AppShell()
         {
+            _history = new List<string>() { };
             InitializeComponent();
             Routing.RegisterRoute(nameof(ItemDetailPage), typeof(ItemDetailPage));
             Routing.RegisterRoute(nameof(NewItemPage), typeof(NewItemPage));
@@ -19,5 +24,37 @@ namespace BlackLion.QRStore
         {
             await Current.GoToAsync("//LoginPage");
         }
+
+        protected override void OnNavigating(ShellNavigatingEventArgs args)
+        {
+            base.OnNavigating(args);
+
+            if (args.Current != null)
+            {
+                if (args.Source == ShellNavigationSource.ShellItemChanged && _action == "DEFAULT")
+                {
+                    _history.Add(args.Current.Location.OriginalString);
+                }
+            }
+        }
+
+        protected override bool OnBackButtonPressed()
+        {
+            if (_history.Count > 0)
+            {
+                var lastRoute = _history[_history.Count - 1];
+                _action = "GOING_BACK";
+
+                _history.RemoveAt(_history.Count - 1);
+                Current.GoToAsync(lastRoute);
+
+                return true;
+            }
+
+            _action = "DEFAULT";
+
+            return base.OnBackButtonPressed();
+        }
+
     }
 }


### PR DESCRIPTION
Navigation between flyout elements now allows the user to go back by pressing the cellphone's back button.